### PR TITLE
Fix filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Example:  mercedes_me_api.sh --token --fuel
      or:  mercedes_me_api.sh -l
 
 The possible arguments are:
-    -t, --token        Procedure to obtatin the Access Token (stored into .mercedes_token)
-    -r, --refresh      Procedure to refresh the Access Token (stored into .mercedes_token)
+    -t, --token        Procedure to obtatin the Access Token (stored into .mercedesme_token)
+    -r, --refresh      Procedure to refresh the Access Token (stored into .mercedesme_token)
     -f, --fuel         Retrive the Fuel Status of your Vehicle
     -l, --lock         Retrive the Lock Status of your Vehicle
     -s, --status       Retrive the General Status of your Vehicle

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The installation is the same, the usage is different.
 ## Installation
 To use this script it's necessary to perform the following instructions:
 1) clone the repository
-2) create a credentials files (.mercedes_credentials) with:
+2) create a credentials files (.mercedesme_credentials) with:
 ```bash
 CLIENT_ID=<**INSERT_YOUR_CLIENT_ID**>
 CLIENT_SECRET=<**INSERT_YOUR_CLIENT_SECRET**>


### PR DESCRIPTION
The config file needs to be called .mercedesme_credentials instead of .mercedes_credentials

Disclosure: I am employed by Daimler AG, the parent company of Mercedes-Benz AG. But while I am affiliated with Mercedes-Benz, I make this contribution as a private individual, *not* in my professional capacity. This contribution is in no way related to my employment with Daimler and/or Mercedes-Benz.