### PR TITLE
Add unique IDs

### DIFF
--- a/custom_components/mercedesmeapi/resources.py
+++ b/custom_components/mercedesmeapi/resources.py
@@ -64,6 +64,11 @@ class MercedesMeResource (Entity):
         self._valid = True
 
     @property
+    def unique_id(self):
+        """Return the unique id of the sensor."""
+        return f"{self._vin}-{self._name}"
+
+    @property
     def name(self):
         """Return the name of the sensor."""
         return self._vin + "_" + self._name


### PR DESCRIPTION
Add unique IDs for sensors. This allows users to rename the sensors and add icons all from within Home Assistant GUI.
Unique IDs are generated by concatenating the VIN with the sensor name, as recommended here https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements

Disclosure: I am employed by Mercedes-Benz AG. But while I am affiliated with Mercedes-Benz, I make this contribution as a private individual, not in my professional capacity. This contribution is in no way related to my employment with Mercedes-Benz AG and/or Mercedes-Benz.