### PR TITLE
Fixed "maximum recursion depth exceeded" issue in custom component

### DIFF
--- a/custom_components/mercedesmeapi/resources.py
+++ b/custom_components/mercedesmeapi/resources.py
@@ -71,7 +71,7 @@ class MercedesMeResource (Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{self._vin}_{self.name}"
+        return f"{self._vin}_{self._name}"
 
     @property
     def state(self):


### PR DESCRIPTION
This fixes a `RecursionError` in the custom component.

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 316, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 374, in _async_add_entity
    suggested_object_id = entity.name
  File "/config/custom_components/mercedesmeapi/resources.py", line 74, in name
    return f"{self._vin}_{self.name}"
  File "/config/custom_components/mercedesmeapi/resources.py", line 74, in name
    return f"{self._vin}_{self.name}"
  File "/config/custom_components/mercedesmeapi/resources.py", line 74, in name
    return f"{self._vin}_{self.name}"
  [Previous line repeated 986 more times]
RecursionError: maximum recursion depth exceeded
```